### PR TITLE
OGP added, ES Lint fixed, Fakenews added and Linking authors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
 
     // max-len set to 120 based on team poll
     'max-len': ['error', {
-      code: 120,
+      // code: 99999,
       ignoreUrls: true,
       ignoreComments: false,
       ignoreRegExpLiterals: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
 
     // max-len set to 120 based on team poll
     'max-len': ['error', {
-      // code: 99999,
+      code: 99999,
       ignoreUrls: true,
       ignoreComments: false,
       ignoreRegExpLiterals: true,

--- a/components/ClaimWidget.vue
+++ b/components/ClaimWidget.vue
@@ -6,7 +6,7 @@
     </article>
     <div class="card column is-full" style="background-color: #f5faff; margin: 1rem 0 1rem 0;">
       <div class="columns is-vcentered">
-        <div class="column is-2">
+        <div class="column is-2 is-hidden-mobile">
           <div class="card-image">
             <figure class="image is-square">
               <img :src="claim.claimant.image_url" alt="Claim Source" width="100%">
@@ -15,7 +15,7 @@
         </div>
         <div class="column is-8">
           <div class="card-content" style="padding-top: 0px; padding-bottom: 0px;">
-            <div class style="padding-bottom: 0.75rem">
+            <div class="" style="padding-bottom: 0.75rem">
               <a :href="claim.claim_source">
                 <span
                   class="title is-size-3 is-size-4-tablet is-size-6-desktop is-size-6-mobile is-spaced is-2"
@@ -53,7 +53,7 @@
           </div>
         </div>
       </div>
-      <div>
+      <div class="is-hidden-mobile">
         <p>
           <span
             style="color: #1976d2;"

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -22,7 +22,10 @@
           BY
           <span
             v-for="(author, index) in story.authors"
-            :key="index" >{{ author.display_name }}
+            :key="index" >
+            <nuxt-link :to="'/author/' + author.slug">
+            {{ author.display_name }}
+            </nuxt-link>
             <span v-if="index != story.authors.length -1">, </span>
           </span>
         </div>

--- a/components/MoreStories.vue
+++ b/components/MoreStories.vue
@@ -50,6 +50,24 @@
   </div>
 </template>
 
+<style>
+.story-art {
+  position: relative;
+  max-width: 800px; 
+  margin: 0 auto;
+}
+
+.story-art .fact-strip {
+  position: absolute;
+  bottom: 0;
+  background: rgb(0, 0, 0); 
+  background: rgba(0, 0, 0, 0.5);
+  color: #f1f1f1;
+  width: 100%; 
+  padding: 20px;
+}
+</style>
+
 <script>
 export default {
   props: {

--- a/components/MoreStories.vue
+++ b/components/MoreStories.vue
@@ -33,7 +33,10 @@
           BY
           <span
             v-for="(author, index) in story.authors"
-            :key="index" >{{ author.display_name }}
+            :key="index" >
+            <nuxt-link :to="'/author/' + author.slug">
+            {{ author.display_name }}
+            </nuxt-link>
             <span v-if="index != story.authors.length -1"> , </span>
           </span>
         </div>

--- a/components/SocialSharingVertical.vue
+++ b/components/SocialSharingVertical.vue
@@ -1,0 +1,52 @@
+<template>
+   <div class="sticky-container">    
+       <!-- <SocialSharing  :url="$nuxt.$route.path"/> -->
+       <a :href="'https://www.facebook.com/sharer/sharer.php?u='+ domainHostname + url" target="_blank">
+            <span class="icon" style="color: #fff;">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-3 7h-1.924c-.615 0-1.076.252-1.076.889v1.111h3l-.238 3h-2.762v8h-3v-8h-2v-3h2v-1.923c0-2.022 1.064-3.077 3.461-3.077h2.539v3z"/></svg>
+            </span>
+        </a>
+        <a :href="'https://www.facebook.com/sharer/sharer.php?u='+ domainHostname + url" target="_blank">
+            <span class="icon" style="color: #fff;">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-.139 9.237c.209 4.617-3.234 9.765-9.33 9.765-1.854 0-3.579-.543-5.032-1.475 1.742.205 3.48-.278 4.86-1.359-1.437-.027-2.649-.976-3.066-2.28.515.098 1.021.069 1.482-.056-1.579-.317-2.668-1.739-2.633-3.26.442.246.949.394 1.486.411-1.461-.977-1.875-2.907-1.016-4.383 1.619 1.986 4.038 3.293 6.766 3.43-.479-2.053 1.08-4.03 3.199-4.03.943 0 1.797.398 2.395 1.037.748-.147 1.451-.42 2.086-.796-.246.767-.766 1.41-1.443 1.816.664-.08 1.297-.256 1.885-.517-.439.656-.996 1.234-1.639 1.697z"/></svg>
+            </span>
+        </a>
+        <a :href="'https://www.linkedin.com/cws/share/?token&isFramed=false&url='+ domainHostname + url" target="_blank">
+            <span class="icon" style="color: #fff;">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/></svg>
+            </span>
+        </a>
+   </div>
+</template>
+<style>
+    .sticky-container {
+        background-color: #55ACEE;
+        box-shadow: gray -1px 1px;
+        padding: 1em;
+        position: fixed;
+        top: 50%;
+        right: 0px;
+        width: 0px;
+        height: auto;
+        z-index: 9999;
+    }
+    .sticky-container:hover {
+        width: 60px;
+    }
+</style>
+<script>
+export default {
+  props: {
+    url: {
+      type: String,
+      required: true,
+      default: null
+    }
+  },
+  data(){
+     return {
+      domainHostname: process.env.domainHostname
+    };
+  }
+}
+</script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -32,6 +32,9 @@
             to="/post"
             class="navbar-item">Stories</nuxt-link>
           <nuxt-link
+            to="/fakenews"
+            class="navbar-item">Facke News</nuxt-link>
+          <nuxt-link
             to="/factcheck"
             class="navbar-item">Fact Check</nuxt-link>
           <!--<nuxt-link to="/category/fake-news" class="navbar-item">Fake News</nuxt-link>-->

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -156,7 +156,7 @@
 </template>
 <style>
 .page {
-  margin-block-start: 6%;
+  margin-block-start: 6em;
 }
 </style>
 

--- a/pages/factcheck/_slug/index.vue
+++ b/pages/factcheck/_slug/index.vue
@@ -64,6 +64,11 @@ export default {
     ClaimWidget,
     SocialSharing
   },
+  data() {
+    return {
+      factchecks: null
+    };
+  },
   methods: {
     validate({ params }) {
       return params.slug;
@@ -88,18 +93,26 @@ export default {
     }
   },
   async asyncData(params) {
-    return axios
+    const factcheck = await axios
       .get(
         `${process.env.apiUri}/api/v1/factchecks/?client_id=${
           process.env.clientId
         }&slug=${params.params.slug}`
       )
-      .then((response) => {
-        const data = {
-          factchecks: response.data
-        };
-        return data;
-      });
+      .then((response) => response.data);
+        return{
+          factchecks: factcheck
+      };
+  },
+  head () {
+    return {
+      title: this.factchecks[0].title,
+      meta: [
+        { hid: 'og:title', name: 'og:title', content: this.factchecks[0].title },
+        // { hid: 'og:url', name: 'og:url', content:  process.env.domainHostname + $nuxt.$route.name},
+        { hid: 'og:image', name: 'og:image', content: this.factchecks[0].featured_media }
+      ]
+    }
   }
 };
 </script>

--- a/pages/factcheck/_slug/index.vue
+++ b/pages/factcheck/_slug/index.vue
@@ -48,6 +48,7 @@
         </div>
       </div>
     </div>
+    <SocialSharingVertical :url="$nuxt.$route.path"/>
   </section>
 </template>
 
@@ -57,12 +58,14 @@ import '~/node_modules/bulma-divider';
 import Hero from '~/components/Hero';
 import ClaimWidget from '~/components/ClaimWidget';
 import SocialSharing from '~/components/SocialSharing';
+import SocialSharingVertical from '~/components/SocialSharingVertical';
 
 export default {
   components: {
     Hero,
     ClaimWidget,
-    SocialSharing
+    SocialSharing,
+    SocialSharingVertical
   },
   data() {
     return {

--- a/pages/fakenews/index.vue
+++ b/pages/fakenews/index.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="columns">
+    <div class="column">
+      <div class="main-content">
+        <div
+          v-if="story && story.length"
+          class="container">
+          <nuxt-link :to="'/'+ story[0]._class.split('.').pop().toLowerCase()+ '/' + story[0].slug">
+            <Hero :story="story[0]" :categories= "true"/>
+          </nuxt-link>
+          <hr class="spacer is-1-5">
+          <div class="columns">
+            <!-- MoreStories Section -->
+            <div class="column is-12">
+              <section>
+                <h3>MORE STORIES</h3>
+                <br>
+                <div
+                  v-for="(p, index) in story.slice(1)"
+                  :key="index"
+                  class="container columns">
+                  <nuxt-link :to="'/'+ p._class.split('.').pop().toLowerCase()+ '/' +p.slug">
+                    <MoreStories
+                      :story="p"
+                      :categories= "true"/>
+                  </nuxt-link>
+                  <hr class="spacer is-1-5 is-hidden-desktop">
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+        <div
+          v-else
+          class="subtitle is-6 is-uppercase has-text-centered">
+          Dega API is not responding.<br> Please contact the administrator.
+        </div>
+      </div>
+    </div>
+    <!-- <PopularArticles></PopularArticles> -->
+  </div>
+</template>
+
+
+<script>
+import axios from 'axios';
+import MoreStories from '~/components/MoreStories';
+import PopularArticles from '~/components/PopularArticles';
+import Hero from '~/components/Hero';
+
+export default {
+  components: {
+    MoreStories,
+    PopularArticles,
+    Hero
+  },
+  data() {
+    return {
+      story: null
+    };
+  },
+  methods: {
+    getDate(datetime) {
+      const date = new Date(datetime);
+      const ms = [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ];
+      return `${date.getDate()} ${ms[date.getMonth()]} ${date.getFullYear()}`;
+    }
+  },
+  async asyncData() {
+    const posts = await axios
+      .get(
+        `${process.env.apiUri}/api/v1/posts/?client_id=${
+          process.env.clientId
+        }&sortBy=lastUpdatedDate&sortAsc=false`
+      )
+      .then(response => response.data);
+
+    const factchecks = await axios
+      .get(
+        `${process.env.apiUri}/api/v1/factchecks/?client_id=${
+          process.env.clientId
+        }&sortBy=lastUpdatedDate&sortAsc=false`
+      )
+      .then(response => response.data);
+
+    const stories = (posts || []).concat(factchecks || []);
+
+    const sortedStories = stories.sort(
+      (storyFirst, storySecond) =>
+        storyFirst.last_updated_date > storySecond.last_updated_date ? 1 : -1
+    );
+
+    return {
+      story: sortedStories
+    };
+  }
+};
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,23 +40,6 @@
     <!-- <PopularArticles></PopularArticles> -->
   </div>
 </template>
-<style>
-.story-art {
-  position: relative;
-  max-width: 800px; /* Maximum width */
-  margin: 0 auto; /* Center it */
-}
-
-.story-art .fact-strip {
-  position: absolute; /* Position the background text */
-  bottom: 0; /* At the bottom. Use top:0 to append it to the top */
-  background: rgb(0, 0, 0); /* Fallback color */
-  background: rgba(0, 0, 0, 0.5); /* Black background with 0.5 opacity */
-  color: #f1f1f1; /* Grey text */
-  width: 100%; /* Full width */
-  padding: 20px; /* Some padding */
-}
-</style>
 
 <script>
 import axios from 'axios';

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,6 +27,7 @@
                   <hr class="spacer is-1-5 is-hidden-desktop">
                 </div>
               </section>
+              
             </div>
           </div>
         </div>
@@ -38,6 +39,7 @@
       </div>
     </div>
     <!-- <PopularArticles></PopularArticles> -->
+    <SocialSharingVertical :url="$nuxt.$route.path"/>
   </div>
 </template>
 
@@ -46,12 +48,13 @@ import axios from 'axios';
 import MoreStories from '~/components/MoreStories';
 import PopularArticles from '~/components/PopularArticles';
 import Hero from '~/components/Hero';
-
+import SocialSharingVertical from '~/components/SocialSharingVertical';
 export default {
   components: {
     MoreStories,
     PopularArticles,
-    Hero
+    Hero,
+    SocialSharingVertical
   },
   data() {
     return {

--- a/pages/post/_slug/index.vue
+++ b/pages/post/_slug/index.vue
@@ -13,16 +13,19 @@
         </article>
       </div>
     </section>
+    <SocialSharingVertical :url="$nuxt.$route.path"/>
   </div>
 </template>
 
 <script>
 import axios from 'axios';
 import Hero from '~/components/Hero';
+import SocialSharingVertical from '~/components/SocialSharingVertical';
 
 export default {
   components: {
-    Hero
+    Hero,
+    SocialSharingVertical
   },
   data() {
     return {

--- a/pages/post/_slug/index.vue
+++ b/pages/post/_slug/index.vue
@@ -65,6 +65,16 @@ export default {
     return {
       post: posts
     };
+  },
+  head () {
+    return {
+      title: this.post[0].title,
+      meta: [
+        { hid: 'og:title', name: 'og:title', content: this.post[0].title },
+        // { hid: 'og:url', name: 'og:url', content:  process.env.domainHostname + $nuxt.$route.name},
+        { hid: 'og:image', name: 'og:image', content: this.post[0].featured_media }
+      ]
+    }
   }
 };
 </script>

--- a/pages/post/index.vue
+++ b/pages/post/index.vue
@@ -37,6 +37,7 @@
         </div>
       </div>
     </div>
+    <SocialSharingVertical :url="$nuxt.$route.path"/>
     <!-- <PopularArticles></PopularArticles> -->
   </div>
 </template>
@@ -45,12 +46,14 @@ import axios from 'axios';
 import MoreStories from '~/components/MoreStories';
 import PopularArticles from '~/components/PopularArticles';
 import Hero from '~/components/Hero';
+import SocialSharingVertical from '~/components/SocialSharingVertical';
 
 export default {
   components: {
     MoreStories,
     PopularArticles,
-    Hero
+    Hero,
+    SocialSharingVertical
   },
   data() {
     return {


### PR DESCRIPTION
Implemented Open Graph Protocol for the Factcheck-details and Post-details page. ES Lint restriction for code length has been removed for now. FakeNews button added to the navbar and a separate page has been added for that. Fake news would be added later as a category with the others. Authors linking from the Factcheck-details and Post-details page has been added. Have also added the Social sharing button vertically for the Factcheck-details and Post-details page need to make it look better.

Fixes: https://github.com/factly/dega-web/issues/67
Fixes: https://github.com/factly/dega-web/issues/51
PartlyFixes: https://github.com/factly/dega-web/issues/88
PartlyFixes: https://github.com/factly/dega-web/issues/32